### PR TITLE
Changed skillets to point to public skillet_tools dockerhub image

### DIFF
--- a/skillets/activate_license.skillet.yaml
+++ b/skillets/activate_license.skillet.yaml
@@ -31,7 +31,7 @@ variables:
 
 snippets:
   - name: ansible_test
-    image: registry.gitlab.com/panw-gse/as/panos_skillet_tools:latest
+    image: docker.io/gsespc/skillet_tools:latest
     async: True
     cmd: |
       ansible-playbook -i 'panos,' ../activate_licenses.yml

--- a/skillets/content_update.skillet.yaml
+++ b/skillets/content_update.skillet.yaml
@@ -26,7 +26,7 @@ variables:
 
 snippets:
   - name: ansible_test
-    image: registry.gitlab.com/panw-gse/as/panos_skillet_tools:latest
+    image: docker.io/gsespc/skillet_tools:latest
     async: True
     cmd: |
       ansible-playbook -i 'panos,' ../perform_content_update.yml

--- a/skillets/deactivate_license.skillet.yaml
+++ b/skillets/deactivate_license.skillet.yaml
@@ -33,7 +33,7 @@ variables:
 
 snippets:
   - name: ansible_test
-    image: registry.gitlab.com/panw-gse/as/panos_skillet_tools:latest
+    image: docker.io/gsespc/skillet_tools:latest
     async: True
     cmd: |
       ansible-playbook -i 'panos,' ../deactivate_licenses.yml

--- a/skillets/full_update.skillet.yaml
+++ b/skillets/full_update.skillet.yaml
@@ -67,7 +67,7 @@ variables:
 
 snippets:
   - name: ansible_test
-    image: registry.gitlab.com/panw-gse/as/panos_skillet_tools:latest 
+    image: docker.io/gsespc/skillet_tools:latest
     async: True
     cmd: |
       ansible-playbook -i 'panos,' ../manage_panos_software.yml


### PR DESCRIPTION
upgrade-downgrade script was failing due to the privatization of the skillet_tools docker image. Changed the skillets to point to new image at dockerhub/gsespc/skillet_tools
